### PR TITLE
Module features to customize setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module to provision an OpenSearch cluster with SAML authentication.
 ## Prerequisites
 
 - A [hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html) to route traffic to your OpenSearch domain
-- An [entityID and metadata XML](https://aws.amazon.com/de/blogs/security/configure-saml-single-sign-on-for-kibana-with-ad-fs-on-amazon-elasticsearch-service/) from your SAML identity provider
+- An [entityID and metadata XML](https://aws.amazon.com/de/blogs/security/configure-saml-single-sign-on-for-kibana-with-ad-fs-on-amazon-elasticsearch-service/) from your SAML identity provider (in case `config_saml = true`)
 
 ## Features
 
@@ -110,7 +110,12 @@ Here is a working example of using this Terraform module:
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The hosted zone name of the OpenSearch cluster. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the OpenSearch cluster. | `string` | `"opensearch"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of OpenSearch to deploy. | `string` | `"1.0"` | no |
+| <a name="input_config_saml"></a> [config\_saml](#input\_config\_saml) | Configure SAML for OpenSearch dashboard | `bool` | `true` | no |
+| <a name="input_create_acm_cert"></a> [create\_acm\_cert](#input\_create\_acm\_cert) | Create the ACM certificate | `bool` | `true` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html | `bool` | `true` | no |
+| <a name="input_custom_endpoint_certificate_arn"></a> [custom\_endpoint\_certificate\_arn](#input\_custom\_endpoint\_certificate\_arn) | Custom endpoint ACM certificate | `string` | n/a | yes |
+| <a name="input_ebs_enabled"></a> [ebs\_enabled](#input\_ebs\_enabled) | If EBS volumes are enabled | `bool` | `false` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Teh size of each EBS volume in GiB | `number` | `10` | no |
 | <a name="input_encrypt_kms_key_id"></a> [encrypt\_kms\_key\_id](#input\_encrypt\_kms\_key\_id) | The KMS key ID to encrypt the OpenSearch cluster with. If not specified, then it defaults to using the AWS OpenSearch Service KMS key. | `string` | `""` | no |
 | <a name="input_hot_instance_count"></a> [hot\_instance\_count](#input\_hot\_instance\_count) | The number of dedicated hot nodes in the cluster. | `number` | `3` | no |
 | <a name="input_hot_instance_type"></a> [hot\_instance\_type](#input\_hot\_instance\_type) | The type of EC2 instances to run for each hot node. A list of available instance types can you find at https://aws.amazon.com/en/opensearch-service/pricing/#On-Demand_instance_pricing | `string` | `"r6gd.4xlarge.elasticsearch"` | no |
@@ -128,11 +133,13 @@ Here is a working example of using this Terraform module:
 | <a name="input_role_mapping_files"></a> [role\_mapping\_files](#input\_role\_mapping\_files) | A set of all role mapping files to create. | `set(string)` | `[]` | no |
 | <a name="input_role_mappings"></a> [role\_mappings](#input\_role\_mappings) | A map of all role mappings to create. | `map(any)` | `{}` | no |
 | <a name="input_roles"></a> [roles](#input\_roles) | A map of all roles to create. | `map(any)` | `{}` | no |
-| <a name="input_saml_entity_id"></a> [saml\_entity\_id](#input\_saml\_entity\_id) | The unique Entity ID of the application in SAML Identity Provider. | `string` | n/a | yes |
-| <a name="input_saml_metadata_content"></a> [saml\_metadata\_content](#input\_saml\_metadata\_content) | The metadata of the SAML application in xml format. | `string` | n/a | yes |
+| <a name="input_saml_entity_id"></a> [saml\_entity\_id](#input\_saml\_entity\_id) | The unique Entity ID of the application in SAML Identity Provider. | `string` | `""` | no |
+| <a name="input_saml_metadata_content"></a> [saml\_metadata\_content](#input\_saml\_metadata\_content) | The metadata of the SAML application in xml format. | `string` | `""` | no |
 | <a name="input_saml_roles_key"></a> [saml\_roles\_key](#input\_saml\_roles\_key) | Element of the SAML assertion to use for backend roles. | `string` | `"http://schemas.microsoft.com/ws/2008/06/identity/claims/role"` | no |
 | <a name="input_saml_session_timeout"></a> [saml\_session\_timeout](#input\_saml\_session\_timeout) | Duration of a session in minutes after a user logs in. Default is 60. Maximum value is 1,440. | `number` | `60` | no |
 | <a name="input_saml_subject_key"></a> [saml\_subject\_key](#input\_saml\_subject\_key) | Element of the SAML assertion to use for username. | `string` | `"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The list of security groups to attach | `list` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The list of subnet to use | `list` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_warm_instance_count"></a> [warm\_instance\_count](#input\_warm\_instance\_count) | The number of dedicated warm nodes in the cluster. | `number` | `3` | no |
 | <a name="input_warm_instance_enabled"></a> [warm\_instance\_enabled](#input\_warm\_instance\_enabled) | Indicates whether ultrawarm nodes are enabled for the cluster. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module to provision an OpenSearch cluster with SAML authentication.
 ## Prerequisites
 
 - A [hosted zone](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html) to route traffic to your OpenSearch domain
-- An [entityID and metadata XML](https://aws.amazon.com/de/blogs/security/configure-saml-single-sign-on-for-kibana-with-ad-fs-on-amazon-elasticsearch-service/) from your SAML identity provider (in case `config_saml = true`)
+- An [entityID and metadata XML](https://aws.amazon.com/de/blogs/security/configure-saml-single-sign-on-for-kibana-with-ad-fs-on-amazon-elasticsearch-service/) from your SAML identity provider (in case `saml_enabled = true`)
 
 ## Features
 
@@ -110,12 +110,13 @@ Here is a working example of using this Terraform module:
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The hosted zone name of the OpenSearch cluster. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the OpenSearch cluster. | `string` | `"opensearch"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of OpenSearch to deploy. | `string` | `"1.0"` | no |
-| <a name="input_config_saml"></a> [config\_saml](#input\_config\_saml) | Configure SAML for OpenSearch dashboard | `bool` | `true` | no |
-| <a name="input_create_acm_cert"></a> [create\_acm\_cert](#input\_create\_acm\_cert) | Create the ACM certificate | `bool` | `true` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html | `bool` | `true` | no |
-| <a name="input_custom_endpoint_certificate_arn"></a> [custom\_endpoint\_certificate\_arn](#input\_custom\_endpoint\_certificate\_arn) | Custom endpoint ACM certificate | `string` | n/a | yes |
-| <a name="input_ebs_enabled"></a> [ebs\_enabled](#input\_ebs\_enabled) | If EBS volumes are enabled | `bool` | `false` | no |
-| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Teh size of each EBS volume in GiB | `number` | `10` | no |
+| <a name="input_custom_endpoint_certificate_arn"></a> [custom\_endpoint\_certificate\_arn](#input\_custom\_endpoint\_certificate\_arn) | The ARN of the custom ACM certificate. | `string` | `""` | no |
+| <a name="input_ebs_enabled"></a> [ebs\_enabled](#input\_ebs\_enabled) | Indicates whether attach EBS volumes to the data nodes. | `bool` | `false` | no |
+| <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. | `number` | `3000` | no |
+| <a name="input_ebs_throughput"></a> [ebs\_throughput](#input\_ebs\_throughput) | The throughput (in MiB/s) of the EBS volumes attached to data nodes. Valid values are between 125 and 1000. | `number` | `125` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | The size of EBS volumes attached to data nodes (in GiB). | `number` | `10` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of EBS volumes attached to data nodes. | `string` | `"gp3"` | no |
 | <a name="input_encrypt_kms_key_id"></a> [encrypt\_kms\_key\_id](#input\_encrypt\_kms\_key\_id) | The KMS key ID to encrypt the OpenSearch cluster with. If not specified, then it defaults to using the AWS OpenSearch Service KMS key. | `string` | `""` | no |
 | <a name="input_hot_instance_count"></a> [hot\_instance\_count](#input\_hot\_instance\_count) | The number of dedicated hot nodes in the cluster. | `number` | `3` | no |
 | <a name="input_hot_instance_type"></a> [hot\_instance\_type](#input\_hot\_instance\_type) | The type of EC2 instances to run for each hot node. A list of available instance types can you find at https://aws.amazon.com/en/opensearch-service/pricing/#On-Demand_instance_pricing | `string` | `"r6gd.4xlarge.elasticsearch"` | no |
@@ -133,21 +134,18 @@ Here is a working example of using this Terraform module:
 | <a name="input_role_mapping_files"></a> [role\_mapping\_files](#input\_role\_mapping\_files) | A set of all role mapping files to create. | `set(string)` | `[]` | no |
 | <a name="input_role_mappings"></a> [role\_mappings](#input\_role\_mappings) | A map of all role mappings to create. | `map(any)` | `{}` | no |
 | <a name="input_roles"></a> [roles](#input\_roles) | A map of all roles to create. | `map(any)` | `{}` | no |
-<<<<<<< HEAD
+| <a name="input_saml_enabled"></a> [saml\_enabled](#input\_saml\_enabled) | Indicates whether to configure SAML for the OpenSearch dashboard. | `bool` | `true` | no |
 | <a name="input_saml_entity_id"></a> [saml\_entity\_id](#input\_saml\_entity\_id) | The unique Entity ID of the application in SAML Identity Provider. | `string` | `""` | no |
-| <a name="input_saml_metadata_content"></a> [saml\_metadata\_content](#input\_saml\_metadata\_content) | The metadata of the SAML application in xml format. | `string` | `""` | no |
-=======
-| <a name="input_saml_entity_id"></a> [saml\_entity\_id](#input\_saml\_entity\_id) | The unique Entity ID of the application in SAML Identity Provider. | `string` | n/a | yes |
 | <a name="input_saml_master_backend_role"></a> [saml\_master\_backend\_role](#input\_saml\_master\_backend\_role) | This backend role receives full permissions to the cluster, equivalent to a new master role, but can only use those permissions within Dashboards. | `string` | `null` | no |
 | <a name="input_saml_master_user_name"></a> [saml\_master\_user\_name](#input\_saml\_master\_user\_name) | This username receives full permissions to the cluster, equivalent to a new master user, but can only use those permissions within Dashboards. | `string` | `null` | no |
-| <a name="input_saml_metadata_content"></a> [saml\_metadata\_content](#input\_saml\_metadata\_content) | The metadata of the SAML application in xml format. | `string` | n/a | yes |
->>>>>>> upstream/main
+| <a name="input_saml_metadata_content"></a> [saml\_metadata\_content](#input\_saml\_metadata\_content) | The metadata of the SAML application in xml format. | `string` | `""` | no |
 | <a name="input_saml_roles_key"></a> [saml\_roles\_key](#input\_saml\_roles\_key) | Element of the SAML assertion to use for backend roles. | `string` | `"http://schemas.microsoft.com/ws/2008/06/identity/claims/role"` | no |
 | <a name="input_saml_session_timeout"></a> [saml\_session\_timeout](#input\_saml\_session\_timeout) | Duration of a session in minutes after a user logs in. Default is 60. Maximum value is 1,440. | `number` | `60` | no |
 | <a name="input_saml_subject_key"></a> [saml\_subject\_key](#input\_saml\_subject\_key) | Element of the SAML assertion to use for username. | `string` | `"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The list of security groups to attach | `list` | `[]` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The list of subnet to use | `list` | `[]` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The list of VPC security groups IDs to attach. | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The list of VPC subnet IDs to use. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_enabled"></a> [vpc\_enabled](#input\_vpc\_enabled) | Indicates whether the cluster is running inside a VPC. | `bool` | `false` | no |
 | <a name="input_warm_instance_count"></a> [warm\_instance\_count](#input\_warm\_instance\_count) | The number of dedicated warm nodes in the cluster. | `number` | `3` | no |
 | <a name="input_warm_instance_enabled"></a> [warm\_instance\_enabled](#input\_warm\_instance\_enabled) | Indicates whether ultrawarm nodes are enabled for the cluster. | `bool` | `true` | no |
 | <a name="input_warm_instance_type"></a> [warm\_instance\_type](#input\_warm\_instance\_type) | The type of EC2 instances to run for each warm node. A list of available instance types can you find at https://aws.amazon.com/en/elasticsearch-service/pricing/#UltraWarm_pricing | `string` | `"ultrawarm1.large.elasticsearch"` | no |

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "aws_elasticsearch_domain" "opensearch" {
 }
 
 resource "aws_elasticsearch_domain_saml_options" "opensearch" {
-  count       = var.config_saml ? 1 : 0
+  count       = var.saml_enabled ? 1 : 0
   domain_name = aws_elasticsearch_domain.opensearch.domain_name
 
   saml_options {

--- a/main.tf
+++ b/main.tf
@@ -75,9 +75,12 @@ resource "aws_elasticsearch_domain" "opensearch" {
     kms_key_id = var.encrypt_kms_key_id
   }
 
-  vpc_options {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = var.security_group_ids
+  dynamic "vpc_options" {
+    for_each = var.vpc_enabled ? [true] : []
+    content {
+      security_group_ids = var.security_group_ids
+      subnet_ids         = var.subnet_ids
+    }
   }
 
   ebs_options {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,10 @@
+moved {
+  from = module.acm
+  to   = module.acm[0]
+}
+
 module "acm" {
-  count   = var.create_acm_cert ? 1 : 0
+  count   = (var.custom_endpoint_certificate_arn != "") ? 0 : 1
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 4.0.1"
 
@@ -58,7 +63,7 @@ resource "aws_elasticsearch_domain" "opensearch" {
 
     custom_endpoint_enabled         = true
     custom_endpoint                 = "${var.cluster_name}.${data.aws_route53_zone.opensearch.name}"
-    custom_endpoint_certificate_arn = var.create_acm_cert ? module.acm.acm_certificate_arn : var.custom_endpoint_certificate_arn
+    custom_endpoint_certificate_arn = (var.custom_endpoint_certificate_arn != "") ? var.custom_endpoint_certificate_arn : module.acm[0].acm_certificate_arn
   }
 
   node_to_node_encryption {

--- a/main.tf
+++ b/main.tf
@@ -83,9 +83,15 @@ resource "aws_elasticsearch_domain" "opensearch" {
     }
   }
 
-  ebs_options {
-    ebs_enabled = var.ebs_enabled
-    volume_size = var.ebs_volume_size
+  dynamic "ebs_options" {
+    for_each = var.ebs_enabled ? [true] : []
+    content {
+      ebs_enabled = true
+      volume_size = var.ebs_volume_size
+      volume_type = var.ebs_volume_type
+      throughput  = var.ebs_throughput
+      iops        = var.ebs_iops
+    }
   }
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "master_instance_type" {
   default     = "r6gd.large.elasticsearch"
 
   validation {
-    condition     = can(regex("^[m3|r3|i3|i2|r6gd]", var.master_instance_type))
+    condition     = can(regex("^[t3|m3|r3|i3|i2|r6gd|c6g]", var.master_instance_type))
     error_message = "The EC2 master_instance_type must provide a SSD or NVMe-based local storage."
   }
 }
@@ -56,7 +56,7 @@ variable "hot_instance_type" {
   default     = "r6gd.4xlarge.elasticsearch"
 
   validation {
-    condition     = can(regex("^[m3|r3|i3|i2|r6gd]", var.hot_instance_type))
+    condition     = can(regex("^[t3|m3|r3|i3|i2|r6gd|c6g]", var.hot_instance_type))
     error_message = "The EC2 hot_instance_type must provide a SSD or NVMe-based local storage."
   }
 }
@@ -91,6 +91,30 @@ variable "availability_zones" {
   default     = 3
 }
 
+variable "subnet_ids" {
+  description = "The list of subnet to use"
+  type        = list(any)
+  default     = []
+}
+
+variable "security_group_ids" {
+  description = "The list of security groups to attach"
+  type        = list(any)
+  default     = []
+}
+
+variable "ebs_enabled" {
+  description = "If EBS volumes are enabled"
+  type        = bool
+  default     = false
+}
+
+variable "ebs_volume_size" {
+  description = "Teh size of each EBS volume in GiB"
+  type        = number
+  default     = 10
+}
+
 variable "encrypt_kms_key_id" {
   description = "The KMS key ID to encrypt the OpenSearch cluster with. If not specified, then it defaults to using the AWS OpenSearch Service KMS key."
   type        = string
@@ -112,11 +136,13 @@ variable "saml_roles_key" {
 variable "saml_entity_id" {
   description = "The unique Entity ID of the application in SAML Identity Provider."
   type        = string
+  default     = ""
 }
 
 variable "saml_metadata_content" {
   description = "The metadata of the SAML application in xml format."
   type        = string
+  default     = ""
 }
 
 variable "saml_session_timeout" {
@@ -189,4 +215,21 @@ variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+}
+
+variable "create_acm_cert" {
+  description = "Create the ACM certificate"
+  type        = bool
+  default     = true
+}
+
+variable "config_saml" {
+  description = "Configure SAML for OpenSearch dashboard"
+  type        = bool
+  default     = true
+}
+
+variable "custom_endpoint_certificate_arn" {
+  description = "Custom endpoint ACM certificate"
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -110,15 +110,33 @@ variable "security_group_ids" {
 }
 
 variable "ebs_enabled" {
-  description = "If EBS volumes are enabled"
+  description = "Indicates whether attach EBS volumes to the data nodes."
   type        = bool
   default     = false
 }
 
 variable "ebs_volume_size" {
-  description = "Teh size of each EBS volume in GiB"
+  description = "The size of EBS volumes attached to data nodes (in GiB)."
   type        = number
   default     = 10
+}
+
+variable "ebs_volume_type" {
+  description = "The type of EBS volumes attached to data nodes."
+  type        = string
+  default     = "gp3"
+}
+
+variable "ebs_throughput" {
+  description = "The throughput (in MiB/s) of the EBS volumes attached to data nodes. Valid values are between 125 and 1000."
+  type        = number
+  default     = 125
+}
+
+variable "ebs_iops" {
+  description = "The baseline input/output (I/O) performance of EBS volumes attached to data nodes."
+  type        = number
+  default     = 3000
 }
 
 variable "encrypt_kms_key_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -229,12 +229,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "create_acm_cert" {
-  description = "Create the ACM certificate"
-  type        = bool
-  default     = true
-}
-
 variable "config_saml" {
   description = "Configure SAML for OpenSearch dashboard"
   type        = bool
@@ -242,6 +236,7 @@ variable "config_saml" {
 }
 
 variable "custom_endpoint_certificate_arn" {
-  description = "Custom endpoint ACM certificate"
+  description = "The ARN of the custom ACM certificate."
   type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,15 +91,21 @@ variable "availability_zones" {
   default     = 3
 }
 
+variable "vpc_enabled" {
+  description = "Indicates whether the cluster is running inside a VPC."
+  type        = bool
+  default     = false
+}
+
 variable "subnet_ids" {
-  description = "The list of subnet to use"
-  type        = list(any)
+  description = "The list of VPC subnet IDs to use."
+  type        = list(string)
   default     = []
 }
 
 variable "security_group_ids" {
-  description = "The list of security groups to attach"
-  type        = list(any)
+  description = "The list of VPC security groups IDs to attach."
+  type        = list(string)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,12 @@ variable "encrypt_kms_key_id" {
   default     = ""
 }
 
+variable "saml_enabled" {
+  description = "Indicates whether to configure SAML for the OpenSearch dashboard."
+  type        = bool
+  default     = true
+}
+
 variable "saml_subject_key" {
   description = "Element of the SAML assertion to use for username."
   type        = string
@@ -251,12 +257,6 @@ variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)
   default     = {}
-}
-
-variable "config_saml" {
-  description = "Configure SAML for OpenSearch dashboard"
-  type        = bool
-  default     = true
 }
 
 variable "custom_endpoint_certificate_arn" {


### PR DESCRIPTION
Hi there

This PR to integrate a bunch of customizations required to setup Amazon OpenSearch domain in dev/test envs.

Addendum involves mainly:
  * Possibility to disable SAML authentication
  * Refer to an existing ACM cert (eg. catch-all cert) without creating a new one
  * Enlarge instance types to use
  * Add VPC and EBS config settings for OpenSearch domain