### PR TITLE
saml_master_backend_role support 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,7 @@ resource "aws_elasticsearch_domain_saml_options" "opensearch" {
     subject_key             = var.saml_subject_key
     roles_key               = var.saml_roles_key
     session_timeout_minutes = var.saml_session_timeout
+    master_backend_role     = var.saml_master_backend_role
 
     idp {
       entity_id        = var.saml_entity_id

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,12 @@ variable "saml_session_timeout" {
   default     = 60
 }
 
+variable "saml_master_backend_role" {
+  description = "The ARN for the master user of the cluster. If not specified, then it defaults to using the IAM user that is making the request."
+  type        = string
+  default     = ""
+}
+
 variable "index_templates" {
   description = "A map of all index templates to create."
   type        = map(any)


### PR DESCRIPTION
I need to be able to define a master role as supported by [phillbaker/terraform-provider-elasticsearch](https://github.com/phillbaker/terraform-provider-elasticsearch) and [amazon](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/saml.html). 