### PR TITLE
Support saml optional master_backend_role and master_user_name params 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "aws_elasticsearch_domain_saml_options" "opensearch" {
     session_timeout_minutes = var.saml_session_timeout
     master_user_name        = var.saml_master_user_name
     master_backend_role     = var.saml_master_backend_role
+
     idp {
       entity_id        = var.saml_entity_id
       metadata_content = sensitive(replace(var.saml_metadata_content, "\ufeff", ""))

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,8 @@ resource "aws_elasticsearch_domain_saml_options" "opensearch" {
     subject_key             = var.saml_subject_key
     roles_key               = var.saml_roles_key
     session_timeout_minutes = var.saml_session_timeout
-
+    master_user_name        = var.saml_master_user_name
+    master_backend_role     = var.saml_master_backend_role
     idp {
       entity_id        = var.saml_entity_id
       metadata_content = sensitive(replace(var.saml_metadata_content, "\ufeff", ""))

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,19 @@ variable "saml_session_timeout" {
   default     = 60
 }
 
+variable "saml_master_backend_role" {
+  description = "This backend role receives full permissions to the cluster, equivalent to a new master role, but can only use those permissions within Dashboards"
+  type        = string
+  default     = ""
+}
+
+variable "saml_master_user_name" {
+  description = "This username receives full permissions to the cluster, equivalent to a new master user, but can only use those permissions within Dashboards"
+  type        = string
+  default     = ""
+}
+
+
 variable "index_templates" {
   description = "A map of all index templates to create."
   type        = map(any)

--- a/variables.tf
+++ b/variables.tf
@@ -126,9 +126,9 @@ variable "saml_session_timeout" {
 }
 
 variable "saml_master_backend_role" {
-  description = "This backend role receives full permissions to the cluster, equivalent to a new master role, but can only use those permissions within Dashboards"
+  description = "This backend role receives full permissions to the cluster, equivalent to a new master role, but can only use those permissions within Dashboards."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "saml_master_user_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -132,11 +132,10 @@ variable "saml_master_backend_role" {
 }
 
 variable "saml_master_user_name" {
-  description = "This username receives full permissions to the cluster, equivalent to a new master user, but can only use those permissions within Dashboards"
+  description = "This username receives full permissions to the cluster, equivalent to a new master user, but can only use those permissions within Dashboards."
   type        = string
-  default     = ""
+  default     = null
 }
-
 
 variable "index_templates" {
   description = "A map of all index templates to create."


### PR DESCRIPTION
 Added support to pass optional master_backend_role and master_user_name parameters to cover the aws_elasticsearch_domain_saml_options resource completely.

     - master_backend_role - (Optional) This backend role from the SAML IdP receives full permissions to the cluster, equivalent to a new master user.
     - master_user_name - (Optional) This username from the SAML IdP receives full permissions to the cluster, equivalent to a new master user.