### PR TITLE
Bump phillbaker/elasticsearch version from 1.6.0 to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Here is a working example of using this Terraform module:
 | [aws_route53_record.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [elasticsearch_index.index](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/index) | resource |
 | [elasticsearch_index_template.index_template](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/index_template) | resource |
-| [elasticsearch_opendistro_ism_policy.ism_policy](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opendistro_ism_policy) | resource |
-| [elasticsearch_opendistro_role.role](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opendistro_role) | resource |
-| [elasticsearch_opendistro_roles_mapping.master_user_arn](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opendistro_roles_mapping) | resource |
-| [elasticsearch_opendistro_roles_mapping.role_mapping](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opendistro_roles_mapping) | resource |
+| [elasticsearch_opensearch_ism_policy.ism_policy](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_ism_policy) | resource |
+| [elasticsearch_opensearch_role.role](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_role) | resource |
+| [elasticsearch_opensearch_roles_mapping.master_user_arn](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
+| [elasticsearch_opensearch_roles_mapping.role_mapping](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ data "http" "saml_metadata" {
 }
 
 provider "elasticsearch" {
-  url                   = "https://${local.cluster_name}.${local.cluster_domain}"
+  url                   = module.opensearch.cluster_endpoint
   aws_region            = data.aws_region.current.name
-  elasticsearch_version = "7.10.2"
   healthcheck           = false
 }
 
@@ -48,7 +47,7 @@ module "opensearch" {
 
   cluster_name    = local.cluster_name
   cluster_domain  = local.cluster_domain
-  cluster_version = "1.0"
+  cluster_version = "1.2"
 
   saml_entity_id        = local.saml_entity_id
   saml_metadata_content = data.http.saml_metadata.body
@@ -75,7 +74,7 @@ Here is a working example of using this Terraform module:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.65 |
-| <a name="requirement_elasticsearch"></a> [elasticsearch](#requirement\_elasticsearch) | >= 1.6.0 |
+| <a name="requirement_elasticsearch"></a> [elasticsearch](#requirement\_elasticsearch) | >= 2.0.0 |
 
 ## Modules
 
@@ -147,7 +146,7 @@ Here is a working example of using this Terraform module:
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | The endpoint URL of the OpenSearch cluster. |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the OpenSearch cluster. |
 | <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The version of the OpenSearch cluster. |
-| <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | The endpoint URL of Kibana. |
+| <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | The endpoint URL of the OpenSearch dashboards. |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,10 +13,9 @@ data "http" "saml_metadata" {
 }
 
 provider "elasticsearch" {
-  url                   = "https://${var.cluster_name}.${var.cluster_domain}"
-  aws_region            = data.aws_region.current.name
-  elasticsearch_version = "7.10.2"
-  healthcheck           = false
+  url         = module.opensearch.cluster_endpoint
+  aws_region  = data.aws_region.current.name
+  healthcheck = false
 }
 
 module "opensearch" {
@@ -24,7 +23,7 @@ module "opensearch" {
 
   cluster_name    = var.cluster_name
   cluster_domain  = var.cluster_domain
-  cluster_version = "1.0"
+  cluster_version = "1.2"
 
   saml_entity_id        = var.saml_entity_id
   saml_metadata_content = data.http.saml_metadata.body

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     elasticsearch = {
       source  = "phillbaker/elasticsearch"
-      version = "2.0.0-beta.2"
+      version = "2.0.0"
     }
   }
 }

--- a/index.tf
+++ b/index.tf
@@ -11,7 +11,7 @@ resource "elasticsearch_index" "index" {
 
   depends_on = [
     elasticsearch_index_template.index_template,
-    elasticsearch_opendistro_ism_policy.ism_policy,
+    elasticsearch_opensearch_ism_policy.ism_policy,
   ]
 
   lifecycle {

--- a/index_template.tf
+++ b/index_template.tf
@@ -4,5 +4,5 @@ resource "elasticsearch_index_template" "index_template" {
   name = each.key
   body = jsonencode(each.value)
 
-  depends_on = [elasticsearch_opendistro_roles_mapping.master_user_arn]
+  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
 }

--- a/ism_policy.tf
+++ b/ism_policy.tf
@@ -1,8 +1,8 @@
-resource "elasticsearch_opendistro_ism_policy" "ism_policy" {
+resource "elasticsearch_opensearch_ism_policy" "ism_policy" {
   for_each = local.ism_policies
 
   policy_id = each.key
   body      = jsonencode({ "policy" = each.value })
 
-  depends_on = [elasticsearch_opendistro_roles_mapping.master_user_arn]
+  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,10 @@ output "cluster_version" {
 
 output "cluster_endpoint" {
   description = "The endpoint URL of the OpenSearch cluster."
-  value       = "https://${aws_route53_record.opensearch.fqdn}"
+  value       = "https://${aws_elasticsearch_domain.opensearch.domain_endpoint_options[0].custom_endpoint}"
 }
 
 output "kibana_endpoint" {
-  description = "The endpoint URL of Kibana."
-  value       = "https://${aws_route53_record.opensearch.fqdn}/_dashboards/"
+  description = "The endpoint URL of the OpenSearch dashboards."
+  value       = "https://${aws_elasticsearch_domain.opensearch.domain_endpoint_options[0].custom_endpoint}/_dashboards/"
 }

--- a/role_mapping.tf
+++ b/role_mapping.tf
@@ -1,4 +1,4 @@
-resource "elasticsearch_opendistro_roles_mapping" "role_mapping" {
+resource "elasticsearch_opensearch_roles_mapping" "role_mapping" {
   for_each = {
     for key, value in local.role_mappings :
     key => value if !contains(["all_access", "security_manager"], key)
@@ -10,10 +10,10 @@ resource "elasticsearch_opendistro_roles_mapping" "role_mapping" {
   hosts         = try(each.value.hosts, [])
   users         = try(each.value.users, [])
 
-  depends_on = [elasticsearch_opendistro_role.role]
+  depends_on = [elasticsearch_opensearch_role.role]
 }
 
-resource "elasticsearch_opendistro_roles_mapping" "master_user_arn" {
+resource "elasticsearch_opensearch_roles_mapping" "master_user_arn" {
   for_each = {
     for key in ["all_access", "security_manager"] :
     key => try(local.role_mappings[key], {})

--- a/roles.tf
+++ b/roles.tf
@@ -1,4 +1,4 @@
-resource "elasticsearch_opendistro_role" "role" {
+resource "elasticsearch_opensearch_role" "role" {
   for_each = local.roles
 
   role_name           = each.key
@@ -22,6 +22,6 @@ resource "elasticsearch_opendistro_role" "role" {
     }
   }
 
-  depends_on = [elasticsearch_opendistro_roles_mapping.master_user_arn]
+  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     elasticsearch = {
       source  = "phillbaker/elasticsearch"
-      version = ">= 1.6.0"
+      version = ">= 2.0.0"
     }
   }
 }


### PR DESCRIPTION
This pull request upgrades the version of the provider phillbaker/elasticsearch from 1.6.0 to 2.0.0.