### PR TITLE
feat(dns): allow for private DNS zone record creation

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -4,6 +4,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_route53_zone" "opensearch" {
   name = var.cluster_domain
+  
+  private_zone = var.cluster_domain_private
 }
 
 data "aws_iam_policy_document" "access_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "cluster_domain" {
   type        = string
 }
 
+variable "cluster_domain_private" {
+  description = "Indicates whether to create records in a private (true) or public (false) zone"
+  type        = bool
+  default     = false
+}
+
 variable "create_service_role" {
   description = "Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html"
   type        = bool


### PR DESCRIPTION
Fixes #26 by adding a new variable `cluster_domain_private` defaulting it to false to keep current behavior in tact. If a user wants to create the DNS record in a private zone they are able to set:
```
cluster_domain_private = true
```