### PR TITLE
Add new variables to control advance settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+**/.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.72.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+      - id: terraform_tflint
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.1
+    rev: v1.79.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
       - id: terraform_docs
       - id: terraform_tflint
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -107,17 +107,12 @@ Here is a working example of using this Terraform module:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-<<<<<<< HEAD
 | <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | IAM policy document specifying the access policies for the domain. | `string` | `null` | no |
-| <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options. | `map(string)` | `{}` | no |
+| <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options. | `map(string)` | `null` | no |
 | <a name="input_advanced_security_options_enabled"></a> [advanced\_security\_options\_enabled](#input\_advanced\_security\_options\_enabled) | Whether advanced security is enabled. | `bool` | `true` | no |
-=======
-| <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options | `map(string)` | `null` | no |
-| <a name="input_advanced_security_options_enabled"></a> [advanced\_security\_options\_enabled](#input\_advanced\_security\_options\_enabled) | AWS Elasticsearch Kibana enchanced security plugin enabling (forces new resource) | `bool` | `false` | no |
 | <a name="input_advanced_security_options_internal_user_database_enabled"></a> [advanced\_security\_options\_internal\_user\_database\_enabled](#input\_advanced\_security\_options\_internal\_user\_database\_enabled) | Whether to enable or not internal Kibana user database for ELK OpenDistro security plugin | `bool` | `false` | no |
 | <a name="input_advanced_security_options_master_user_name"></a> [advanced\_security\_options\_master\_user\_name](#input\_advanced\_security\_options\_master\_user\_name) | Master user username (applicable if advanced\_security\_options\_internal\_user\_database\_enabled set to true) | `string` | `null` | no |
 | <a name="input_advanced_security_options_master_user_password"></a> [advanced\_security\_options\_master\_user\_password](#input\_advanced\_security\_options\_master\_user\_password) | Master user password (applicable if advanced\_security\_options\_internal\_user\_database\_enabled set to true) | `string` | `null` | no |
->>>>>>> e1ea4cf (feat(advance settings): Add variables to control it)
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The number of availability zones for the OpenSearch cluster. Valid values: 1, 2 or 3. | `number` | `3` | no |
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The hosted zone name of the OpenSearch cluster. | `string` | n/a | yes |
 | <a name="input_cluster_domain_private"></a> [cluster\_domain\_private](#input\_cluster\_domain\_private) | Indicates whether to create records in a private (true) or public (false) zone | `bool` | `false` | no |
@@ -132,6 +127,7 @@ Here is a working example of using this Terraform module:
 | <a name="input_ebs_throughput"></a> [ebs\_throughput](#input\_ebs\_throughput) | The throughput (in MiB/s) of the EBS volumes attached to data nodes. Valid values are between 125 and 1000. | `number` | `125` | no |
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | The size of EBS volumes attached to data nodes (in GiB). | `number` | `10` | no |
 | <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of EBS volumes attached to data nodes. | `string` | `"gp3"` | no |
+| <a name="input_encrypt_at_rest_enabled"></a> [encrypt\_at\_rest\_enabled](#input\_encrypt\_at\_rest\_enabled) | Configuration block for encrypt at rest options | `bool` | `true` | no |
 | <a name="input_encrypt_kms_key_id"></a> [encrypt\_kms\_key\_id](#input\_encrypt\_kms\_key\_id) | The KMS key ID to encrypt the OpenSearch cluster with. If not specified, then it defaults to using the AWS OpenSearch Service KMS key. | `string` | `""` | no |
 | <a name="input_hot_instance_count"></a> [hot\_instance\_count](#input\_hot\_instance\_count) | The number of dedicated hot nodes in the cluster. | `number` | `3` | no |
 | <a name="input_hot_instance_type"></a> [hot\_instance\_type](#input\_hot\_instance\_type) | The type of EC2 instances to run for each hot node. A list of available instance types can you find at https://aws.amazon.com/en/opensearch-service/pricing/#On-Demand_instance_pricing | `string` | `"r6gd.4xlarge.elasticsearch"` | no |
@@ -145,6 +141,7 @@ Here is a working example of using this Terraform module:
 | <a name="input_master_instance_enabled"></a> [master\_instance\_enabled](#input\_master\_instance\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster. | `bool` | `true` | no |
 | <a name="input_master_instance_type"></a> [master\_instance\_type](#input\_master\_instance\_type) | The type of EC2 instances to run for each master node. A list of available instance types can you find at https://aws.amazon.com/en/opensearch-service/pricing/#On-Demand_instance_pricing | `string` | `"r6gd.large.elasticsearch"` | no |
 | <a name="input_master_user_arn"></a> [master\_user\_arn](#input\_master\_user\_arn) | The ARN for the master user of the cluster. If not specified, then it defaults to using the IAM user that is making the request. | `string` | `""` | no |
+| <a name="input_node_to_node_encryption_enabled"></a> [node\_to\_node\_encryption\_enabled](#input\_node\_to\_node\_encryption\_enabled) | Configuration block for node-to-node encryption options | `bool` | `true` | no |
 | <a name="input_role_files"></a> [role\_files](#input\_role\_files) | A set of all role files to create. | `set(string)` | `[]` | no |
 | <a name="input_role_mapping_files"></a> [role\_mapping\_files](#input\_role\_mapping\_files) | A set of all role mapping files to create. | `set(string)` | `[]` | no |
 | <a name="input_role_mappings"></a> [role\_mappings](#input\_role\_mappings) | A map of all role mappings to create. | `map(any)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -107,9 +107,17 @@ Here is a working example of using this Terraform module:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+<<<<<<< HEAD
 | <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | IAM policy document specifying the access policies for the domain. | `string` | `null` | no |
 | <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options. | `map(string)` | `{}` | no |
 | <a name="input_advanced_security_options_enabled"></a> [advanced\_security\_options\_enabled](#input\_advanced\_security\_options\_enabled) | Whether advanced security is enabled. | `bool` | `true` | no |
+=======
+| <a name="input_advanced_options"></a> [advanced\_options](#input\_advanced\_options) | Key-value string pairs to specify advanced configuration options | `map(string)` | `null` | no |
+| <a name="input_advanced_security_options_enabled"></a> [advanced\_security\_options\_enabled](#input\_advanced\_security\_options\_enabled) | AWS Elasticsearch Kibana enchanced security plugin enabling (forces new resource) | `bool` | `false` | no |
+| <a name="input_advanced_security_options_internal_user_database_enabled"></a> [advanced\_security\_options\_internal\_user\_database\_enabled](#input\_advanced\_security\_options\_internal\_user\_database\_enabled) | Whether to enable or not internal Kibana user database for ELK OpenDistro security plugin | `bool` | `false` | no |
+| <a name="input_advanced_security_options_master_user_name"></a> [advanced\_security\_options\_master\_user\_name](#input\_advanced\_security\_options\_master\_user\_name) | Master user username (applicable if advanced\_security\_options\_internal\_user\_database\_enabled set to true) | `string` | `null` | no |
+| <a name="input_advanced_security_options_master_user_password"></a> [advanced\_security\_options\_master\_user\_password](#input\_advanced\_security\_options\_master\_user\_password) | Master user password (applicable if advanced\_security\_options\_internal\_user\_database\_enabled set to true) | `string` | `null` | no |
+>>>>>>> e1ea4cf (feat(advance settings): Add variables to control it)
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The number of availability zones for the OpenSearch cluster. Valid values: 1, 2 or 3. | `number` | `3` | no |
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The hosted zone name of the OpenSearch cluster. | `string` | n/a | yes |
 | <a name="input_cluster_domain_private"></a> [cluster\_domain\_private](#input\_cluster\_domain\_private) | Indicates whether to create records in a private (true) or public (false) zone | `bool` | `false` | no |

--- a/data.tf
+++ b/data.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "current" {}
 
 data "aws_route53_zone" "opensearch" {
   name = var.cluster_domain
-  
+
   private_zone = var.cluster_domain_private
 }
 

--- a/main.tf
+++ b/main.tf
@@ -53,10 +53,12 @@ resource "aws_elasticsearch_domain" "opensearch" {
     for_each = var.advanced_security_options_enabled ? [true] : []
     content {
       enabled                        = var.advanced_security_options_enabled
-      internal_user_database_enabled = false
+      internal_user_database_enabled = var.advanced_security_options_internal_user_database_enabled
 
       master_user_options {
         master_user_arn = (var.master_user_arn != "") ? var.master_user_arn : data.aws_caller_identity.current.arn
+        master_user_name     = var.advanced_security_options_master_user_name
+        master_user_password = var.advanced_security_options_master_user_password
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -56,9 +56,9 @@ resource "aws_elasticsearch_domain" "opensearch" {
       internal_user_database_enabled = var.advanced_security_options_internal_user_database_enabled
 
       master_user_options {
-        master_user_arn = (var.master_user_arn != "") ? var.master_user_arn : data.aws_caller_identity.current.arn
-        master_user_name     = var.advanced_security_options_master_user_name
-        master_user_password = var.advanced_security_options_master_user_password
+        master_user_arn      = var.advanced_security_options_internal_user_database_enabled ? null : (var.master_user_arn != "" ? var.master_user_arn : data.aws_caller_identity.current.arn)
+        master_user_name     = var.advanced_security_options_internal_user_database_enabled ? var.advanced_security_options_master_user_name : null
+        master_user_password = var.advanced_security_options_internal_user_database_enabled ? var.advanced_security_options_master_user_password : null
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -73,11 +73,11 @@ resource "aws_elasticsearch_domain" "opensearch" {
   }
 
   node_to_node_encryption {
-    enabled = true
+    enabled = var.node_to_node_encryption_enabled
   }
 
   encrypt_at_rest {
-    enabled    = true
+    enabled    = var.encrypt_at_rest_enabled
     kms_key_id = var.encrypt_kms_key_id
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -318,3 +318,15 @@ variable "advanced_security_options_master_user_password" {
   type        = string
   default     = null
 }
+
+variable "node_to_node_encryption_enabled" {
+  description = "Configuration block for node-to-node encryption options"
+  type        = bool
+  default     = true
+}
+
+variable "encrypt_at_rest_enabled" {
+  description = "Configuration block for encrypt at rest options"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -300,3 +300,21 @@ variable "access_policies" {
   type        = string
   default     = null
 }
+
+variable "advanced_security_options_internal_user_database_enabled" {
+  description = "Whether to enable or not internal Kibana user database for ELK OpenDistro security plugin"
+  type        = bool
+  default     = false
+}
+
+variable "advanced_security_options_master_user_name" {
+  description = "Master user username (applicable if advanced_security_options_internal_user_database_enabled set to true)"
+  type        = string
+  default     = null
+}
+
+variable "advanced_security_options_master_user_password" {
+  description = "Master user password (applicable if advanced_security_options_internal_user_database_enabled set to true)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# Description
This makes the module more flexible in general, but in particular, for our use case, it makes it possible to import manually already created clusters into Terraform.

- Add [pre-commit conf (hooks)](https://github.com/antonbabenko/pre-commit-terraform) useful for linter and docs automation
  From now on, one can do `pre-commit install` on the local repo and checks will run on every commit.
- Add 2 new variables to control security options
- Add 2 new variables to control  encryption options