### PR TITLE
chore(custom_endpoint): Allow defining one

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Here is a working example of using this Terraform module:
 | <a name="input_cognito_options"></a> [cognito\_options](#input\_cognito\_options) | Configuration block for authenticating Kibana with Cognito. | `map(string)` | `{}` | no |
 | <a name="input_cognito_options_enabled"></a> [cognito\_options\_enabled](#input\_cognito\_options\_enabled) | Whether Amazon Cognito authentication with Kibana is enabled or not. | `bool` | `false` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html | `bool` | `true` | no |
+| <a name="input_custom_endpoint"></a> [custom\_endpoint](#input\_custom\_endpoint) | Fully qualified domain for your custom endpoint. If not specified, then it defaults to <cluster\_name>.<cluster\_domain> | `string` | `null` | no |
 | <a name="input_custom_endpoint_certificate_arn"></a> [custom\_endpoint\_certificate\_arn](#input\_custom\_endpoint\_certificate\_arn) | The ARN of the custom ACM certificate. | `string` | `""` | no |
 | <a name="input_ebs_enabled"></a> [ebs\_enabled](#input\_ebs\_enabled) | Indicates whether attach EBS volumes to the data nodes. | `bool` | `false` | no |
 | <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. | `number` | `3000` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -28,4 +28,6 @@ locals {
     replace(basename(filename), "/\\.(ya?ml|json)$/", "") =>
     length(regexall("\\.ya?ml$", filename)) > 0 ? yamldecode(file(filename)) : jsondecode(file(filename))
   }, var.role_mappings)
+
+  custom_endpoint = var.custom_endpoint != null ? var.custom_endpoint : "${var.cluster_name}.${data.aws_route53_zone.opensearch.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 4.3.1"
 
-  domain_name = "${var.cluster_name}.${data.aws_route53_zone.opensearch.name}"
+  domain_name = local.custom_endpoint
   zone_id     = data.aws_route53_zone.opensearch.id
 
   wait_for_validation = true
@@ -68,7 +68,7 @@ resource "aws_elasticsearch_domain" "opensearch" {
     tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
     custom_endpoint_enabled         = true
-    custom_endpoint                 = "${var.cluster_name}.${data.aws_route53_zone.opensearch.name}"
+    custom_endpoint                 = local.custom_endpoint
     custom_endpoint_certificate_arn = (var.custom_endpoint_certificate_arn != "") ? var.custom_endpoint_certificate_arn : module.acm[0].acm_certificate_arn
   }
 
@@ -136,7 +136,7 @@ resource "aws_elasticsearch_domain_saml_options" "opensearch" {
 
 resource "aws_route53_record" "opensearch" {
   zone_id = data.aws_route53_zone.opensearch.id
-  name    = var.cluster_name
+  name    = trimsuffix(local.custom_endpoint, var.cluster_domain)
   type    = "CNAME"
   ttl     = "60"
 

--- a/variables.tf
+++ b/variables.tf
@@ -265,6 +265,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "custom_endpoint" {
+  description = "Fully qualified domain for your custom endpoint. If not specified, then it defaults to <cluster_name>.<cluster_domain>"
+  type        = string
+  default     = null
+}
+
 variable "custom_endpoint_certificate_arn" {
   description = "The ARN of the custom ACM certificate."
   type        = string


### PR DESCRIPTION
# Description
Make the module more flexible especially when importing existing clusters into Terraform. Close #25 
- Add a new variable for defining the custom_endpoint
- Define the logic in the main code
- Update docs 