### PR TITLE
Add Route53 record dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Here is a working example of using this Terraform module:
 | [elasticsearch_opensearch_ism_policy.ism_policy](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_ism_policy) | resource |
 | [elasticsearch_opensearch_role.role](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_role) | resource |
 | [elasticsearch_opensearch_roles_mapping.master_user_arn](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
+| [elasticsearch_opensearch_roles_mapping.master_user_name](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
 | [elasticsearch_opensearch_roles_mapping.role_mapping](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "phillbaker/elasticsearch"
       version = ">= 2.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
   }
 }

--- a/examples/minimal/versions.tf
+++ b/examples/minimal/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "phillbaker/elasticsearch"
       version = ">= 2.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
   }
 }

--- a/index.tf
+++ b/index.tf
@@ -12,6 +12,7 @@ resource "elasticsearch_index" "index" {
   depends_on = [
     elasticsearch_index_template.index_template,
     elasticsearch_opensearch_ism_policy.ism_policy,
+    aws_route53_record.opensearch
   ]
 
   lifecycle {

--- a/index_template.tf
+++ b/index_template.tf
@@ -4,5 +4,8 @@ resource "elasticsearch_index_template" "index_template" {
   name = each.key
   body = jsonencode(each.value)
 
-  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
+  depends_on = [
+    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    aws_route53_record.opensearch
+  ]
 }

--- a/ism_policy.tf
+++ b/ism_policy.tf
@@ -4,5 +4,8 @@ resource "elasticsearch_opensearch_ism_policy" "ism_policy" {
   policy_id = each.key
   body      = jsonencode({ "policy" = each.value })
 
-  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
+  depends_on = [
+    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    aws_route53_record.opensearch
+  ]
 }

--- a/role_mapping.tf
+++ b/role_mapping.tf
@@ -10,7 +10,10 @@ resource "elasticsearch_opensearch_roles_mapping" "role_mapping" {
   hosts         = try(each.value.hosts, [])
   users         = try(each.value.users, [])
 
-  depends_on = [elasticsearch_opensearch_role.role]
+  depends_on = [
+    elasticsearch_opensearch_role.role,
+    aws_route53_record.opensearch
+  ]
 }
 
 resource "elasticsearch_opensearch_roles_mapping" "master_user_arn" {

--- a/roles.tf
+++ b/roles.tf
@@ -22,6 +22,9 @@ resource "elasticsearch_opensearch_role" "role" {
     }
   }
 
-  depends_on = [elasticsearch_opensearch_roles_mapping.master_user_arn]
+  depends_on = [
+    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    aws_route53_record.opensearch
+  ]
 }
 


### PR DESCRIPTION
Without this the module was trying to create Elasticsearch resources before the DNS entry and therefore the cluster was created:

```
module.acm[0].aws_acm_certificate_validation.this[0]: Creating...
module.acm[0].aws_acm_certificate_validation.this[0]: Creation complete after 0s [id=2023-08-03 19:26:52.495 +0000 UTC]

Error: Get "https://elk.domain.com/": dial tcp: lookup elk.domain.com on 10.1.0.2:53: no such host

  with elasticsearch_index_template.index_template["live_transcription_events"],
  on index_template.tf line 1, in resource "elasticsearch_index_template" "index_template":
   1: resource "elasticsearch_index_template" "index_template" {
```

With this change the Cluster is created, then the Route53 host and all Elasticsearch resources are created properly.

Additionally, I added a change to the examples folder to make sure tflint checks pass.