### PR TITLE
feat(provider): migrate to dedicated OpenSearch provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here is a working example of using this Terraform module:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
-| <a name="requirement_elasticsearch"></a> [elasticsearch](#requirement\_elasticsearch) | >= 2.0.0 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 2.0.0 |
 
 ## Modules
 
@@ -94,14 +94,14 @@ Here is a working example of using this Terraform module:
 | [aws_elasticsearch_domain_saml_options.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain_saml_options) | resource |
 | [aws_iam_service_linked_role.es](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_route53_record.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [elasticsearch_composable_index_template.composable_index_template](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/composable_index_template) | resource |
-| [elasticsearch_index.index](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/index) | resource |
-| [elasticsearch_index_template.index_template](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/index_template) | resource |
-| [elasticsearch_opensearch_ism_policy.ism_policy](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_ism_policy) | resource |
-| [elasticsearch_opensearch_role.role](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_role) | resource |
-| [elasticsearch_opensearch_roles_mapping.master_user_arn](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
-| [elasticsearch_opensearch_roles_mapping.master_user_name](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
-| [elasticsearch_opensearch_roles_mapping.role_mapping](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_roles_mapping) | resource |
+| [opensearch_composable_index_template.composable_index_template](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/composable_index_template) | resource |
+| [opensearch_index.index](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/index) | resource |
+| [opensearch_index_template.index_template](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/index_template) | resource |
+| [opensearch_ism_policy.ism_policy](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/ism_policy) | resource |
+| [opensearch_role.role](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/role) | resource |
+| [opensearch_roles_mapping.master_user_arn](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
+| [opensearch_roles_mapping.master_user_name](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
+| [opensearch_roles_mapping.role_mapping](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -124,7 +124,7 @@ Here is a working example of using this Terraform module:
 | <a name="input_cluster_domain"></a> [cluster\_domain](#input\_cluster\_domain) | The hosted zone name of the OpenSearch cluster. | `string` | n/a | yes |
 | <a name="input_cluster_domain_private"></a> [cluster\_domain\_private](#input\_cluster\_domain\_private) | Indicates whether to create records in a private (true) or public (false) zone | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the OpenSearch cluster. | `string` | `"opensearch"` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of OpenSearch to deploy. | `string` | `"1.0"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of OpenSearch to deploy. | `string` | `"2.11"` | no |
 | <a name="input_cognito_options"></a> [cognito\_options](#input\_cognito\_options) | Configuration block for authenticating Kibana with Cognito. | `map(string)` | `{}` | no |
 | <a name="input_cognito_options_enabled"></a> [cognito\_options\_enabled](#input\_cognito\_options\_enabled) | Whether Amazon Cognito authentication with Kibana is enabled or not. | `bool` | `false` | no |
 | <a name="input_composable_index_template_files"></a> [composable\_index\_template\_files](#input\_composable\_index\_template\_files) | A set of all composable index template files to create. | `set(string)` | `[]` | no |

--- a/composable_index_template.tf
+++ b/composable_index_template.tf
@@ -1,11 +1,11 @@
-resource "elasticsearch_composable_index_template" "composable_index_template" {
+resource "opensearch_composable_index_template" "composable_index_template" {
   for_each = local.composable_index_templates
 
   name = each.key
   body = jsonencode(each.value)
 
   depends_on = [
-    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    opensearch_roles_mapping.master_user_arn,
     aws_route53_record.opensearch
   ]
 }

--- a/examples/complete/index-templates/example-template.yml
+++ b/examples/complete/index-templates/example-template.yml
@@ -1,17 +1,18 @@
 ---
 index_patterns:
 - example-*
-settings:
-  index:
-    number_of_shards: "2"
-    number_of_replicas: "1"
-    refresh_interval: 30s
-mappings:
-  _source:
-    enabled: false
-  properties:
-    created_at:
-      format: EEE MMM dd HH:mm:ss Z YYYY
-      type: date
-    host_name:
-      type: keyword
+template:
+  settings:
+    index:
+      number_of_shards: "2"
+      number_of_replicas: "1"
+      refresh_interval: 30s
+  mappings:
+    _source:
+      enabled: false
+    properties:
+      created_at:
+        format: EEE MMM dd HH:mm:ss Z YYYY
+        type: date
+      host_name:
+        type: keyword

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,7 +12,7 @@ data "http" "saml_metadata" {
   url = var.saml_metadata_url
 }
 
-provider "elasticsearch" {
+provider "opensearch" {
   url         = module.opensearch.cluster_endpoint
   aws_region  = data.aws_region.current.name
   healthcheck = false
@@ -23,7 +23,7 @@ module "opensearch" {
 
   cluster_name    = var.cluster_name
   cluster_domain  = var.cluster_domain
-  cluster_version = "1.3"
+  cluster_version = "2.11"
 
   saml_entity_id        = var.saml_entity_id
   saml_metadata_content = data.http.saml_metadata.body

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,8 +6,8 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
-    elasticsearch = {
-      source  = "phillbaker/elasticsearch"
+    opensearch = {
+      source  = "opensearch-project/opensearch"
       version = ">= 2.0"
     }
     http = {

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 data "aws_region" "current" {}
 
-provider "elasticsearch" {
+provider "opensearch" {
   url         = module.opensearch.cluster_endpoint
   aws_region  = data.aws_region.current.name
   healthcheck = false
@@ -19,7 +19,7 @@ module "opensearch" {
 
   cluster_name    = var.cluster_name
   cluster_domain  = var.cluster_domain
-  cluster_version = "1.3"
+  cluster_version = "2.11"
 
   saml_enabled = false
 }

--- a/examples/minimal/versions.tf
+++ b/examples/minimal/versions.tf
@@ -6,8 +6,8 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
-    elasticsearch = {
-      source  = "phillbaker/elasticsearch"
+    opensearch = {
+      source  = "opensearch-project/opensearch"
       version = ">= 2.0"
     }
     http = {

--- a/index.tf
+++ b/index.tf
@@ -1,4 +1,4 @@
-resource "elasticsearch_index" "index" {
+resource "opensearch_index" "index" {
   for_each = local.indices
 
   name               = each.key
@@ -10,8 +10,8 @@ resource "elasticsearch_index" "index" {
   force_destroy      = true
 
   depends_on = [
-    elasticsearch_index_template.index_template,
-    elasticsearch_opensearch_ism_policy.ism_policy,
+    opensearch_index_template.index_template,
+    opensearch_ism_policy.ism_policy,
     aws_route53_record.opensearch
   ]
 

--- a/index_template.tf
+++ b/index_template.tf
@@ -1,11 +1,11 @@
-resource "elasticsearch_index_template" "index_template" {
+resource "opensearch_index_template" "index_template" {
   for_each = local.index_templates
 
   name = each.key
   body = jsonencode(each.value)
 
   depends_on = [
-    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    opensearch_roles_mapping.master_user_arn,
     aws_route53_record.opensearch
   ]
 }

--- a/ism_policy.tf
+++ b/ism_policy.tf
@@ -1,11 +1,11 @@
-resource "elasticsearch_opensearch_ism_policy" "ism_policy" {
+resource "opensearch_ism_policy" "ism_policy" {
   for_each = local.ism_policies
 
   policy_id = each.key
   body      = jsonencode({ "policy" = each.value })
 
   depends_on = [
-    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    opensearch_roles_mapping.master_user_arn,
     aws_route53_record.opensearch
   ]
 }

--- a/role_mapping.tf
+++ b/role_mapping.tf
@@ -1,4 +1,4 @@
-resource "elasticsearch_opensearch_roles_mapping" "role_mapping" {
+resource "opensearch_roles_mapping" "role_mapping" {
   for_each = {
     for key, value in local.role_mappings :
     key => value if !contains(["all_access", "security_manager"], key)
@@ -11,12 +11,12 @@ resource "elasticsearch_opensearch_roles_mapping" "role_mapping" {
   users         = try(each.value.users, [])
 
   depends_on = [
-    elasticsearch_opensearch_role.role,
+    opensearch_role.role,
     aws_route53_record.opensearch
   ]
 }
 
-resource "elasticsearch_opensearch_roles_mapping" "master_user_arn" {
+resource "opensearch_roles_mapping" "master_user_arn" {
   for_each = var.advanced_security_options_internal_user_database_enabled ? {} : {
     for key in ["all_access", "security_manager"] :
     key => try(local.role_mappings[key], {})
@@ -31,7 +31,7 @@ resource "elasticsearch_opensearch_roles_mapping" "master_user_arn" {
   depends_on = [aws_route53_record.opensearch]
 }
 
-resource "elasticsearch_opensearch_roles_mapping" "master_user_name" {
+resource "opensearch_roles_mapping" "master_user_name" {
   for_each = var.advanced_security_options_internal_user_database_enabled ? {
     for key in ["all_access", "security_manager"] :
     key => try(local.role_mappings[key], {})

--- a/roles.tf
+++ b/roles.tf
@@ -1,4 +1,4 @@
-resource "elasticsearch_opensearch_role" "role" {
+resource "opensearch_role" "role" {
   for_each = local.roles
 
   role_name           = each.key
@@ -23,7 +23,7 @@ resource "elasticsearch_opensearch_role" "role" {
   }
 
   depends_on = [
-    elasticsearch_opensearch_roles_mapping.master_user_arn,
+    opensearch_roles_mapping.master_user_arn,
     aws_route53_record.opensearch
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "The version of OpenSearch to deploy."
   type        = string
-  default     = "1.0"
+  default     = "2.11"
 }
 
 variable "cluster_domain" {

--- a/versions.tf
+++ b/versions.tf
@@ -6,8 +6,8 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.12.0"
     }
-    elasticsearch = {
-      source  = "phillbaker/elasticsearch"
+    opensearch = {
+      source  = "opensearch-project/opensearch"
       version = ">= 2.0.0"
     }
   }


### PR DESCRIPTION
This pull request migrates all resources to the [new dedicated provider](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs) for OpenSearch. Fixes #53.